### PR TITLE
[#9] image list now filters for both image and tag instead of just image

### DIFF
--- a/pkg/run/agent.go
+++ b/pkg/run/agent.go
@@ -37,11 +37,9 @@ func NewAgent(client *docker.Client) (*Agent, error) {
 // present and pulls it if necessary. Set `verbose` to `true` to see the
 // Docker engine's output in stdout.
 func (ag *Agent) VerifyImagePresent(imgref string, verbose bool) error {
-	imgsegs := strings.Split(imgref, ":")
-
 	imgs, err := ag.client.ListImages(docker.ListImagesOptions{
 		All:    true,
-		Filter: imgsegs[0],
+		Filter: imgref,
 	})
 	if err != nil {
 		return err
@@ -50,6 +48,8 @@ func (ag *Agent) VerifyImagePresent(imgref string, verbose bool) error {
 	if len(imgs) > 0 {
 		return nil
 	}
+
+	imgsegs := strings.Split(imgref, ":")
 
 	pullopts := docker.PullImageOptions{
 		Repository: imgsegs[0],


### PR DESCRIPTION
This fixes a bug in `VerifyImagePresent` where it would incorrectly filter for an image just based on the repository, not the tag. This led to assuming an image was present if your Docker daemon contained any tag of that image repository, instead of the specific one you requested.

This PR addresses issue #9 .